### PR TITLE
Fix bug where all representations on namespaces would be set to the deepest of the chain;

### DIFF
--- a/src/Builders/namespaceBuilder.cpp
+++ b/src/Builders/namespaceBuilder.cpp
@@ -14,7 +14,8 @@ namespace {
  * If it doesn't exist, create it and return the new child
  */
 IR::Namespace* createOrGetChild(IR::Namespace* parent,
-                                std::string_view childName) {
+                                std::string_view childName,
+                                std::string_view childRepresentation) {
 	auto& children = parent->m_namespaces;
 	// Check if the child exists
 	if (auto child = std::find_if(children.begin(),
@@ -28,6 +29,7 @@ IR::Namespace* createOrGetChild(IR::Namespace* parent,
 	// Create the child
 	IR::Namespace childNS;
 	childNS.m_name = childName;
+	childNS.m_representation = childRepresentation;
 	return &children.emplace_back(childNS);
 }
 
@@ -42,8 +44,7 @@ void addNamespaceToRoot(IR::Namespace& rootNS,
 		auto& name = ns.front();
 		auto parentName = currentNs->m_name;
 		// Set child
-		currentNs = createOrGetChild(currentNs, name);
-		currentNs->m_representation = representation;
+		currentNs = createOrGetChild(currentNs, name, representation);
 		ns.pop_front();
 	}
 }

--- a/src/Visitor/ParserVisitor.hpp
+++ b/src/Visitor/ParserVisitor.hpp
@@ -1,8 +1,9 @@
 #pragma once
 
-#include "IR/ir.hpp"
 #include "IRProxy/IRData.hpp"
+#include <IR/ir.hpp>
 #include <clang/AST/RecursiveASTVisitor.h>
+#include <clang/Basic/SourceManager.h>
 
 namespace Visitor {
 class ParserVisitor : public clang::RecursiveASTVisitor<ParserVisitor> {

--- a/src/Visitor/VisitNamespaceDecl.cpp
+++ b/src/Visitor/VisitNamespaceDecl.cpp
@@ -1,6 +1,7 @@
 #include "Visitor/ParserVisitor.hpp"
 #include "clang/AST/DeclBase.h"
 #include "clang/AST/Type.h"
+#include <iostream>
 #include <spdlog/spdlog.h>
 
 namespace Visitor {
@@ -12,6 +13,9 @@ bool ParserVisitor::VisitNamespaceDecl(clang::NamespaceDecl* namespaceDecl) {
 	}
 	spdlog::debug("Parsing namespace: {}",
 	              namespaceDecl->getQualifiedNameAsString());
+
+	std::cout << "On namespace: " << namespaceDecl->getQualifiedNameAsString()
+	          << '\n';
 
 	// Export our parsed namespace
 	m_irData.m_namespaces.push_back(namespaceDecl->getQualifiedNameAsString());


### PR DESCRIPTION
```
namespace A {
  namespace B {
  }
}
```

Here `representation(A) == A::B`, while it should be just `'A'`