### PR TITLE
Use clang::PrintingPolicy to ensure that at least the top level repre…

### DIFF
--- a/src/Builders/typeBuilder.hpp
+++ b/src/Builders/typeBuilder.hpp
@@ -15,9 +15,11 @@ namespace Builders {
 *         If it fails it returns std::nullopt
 *
 * @param: std::string_view type
+*         const clang::PrintingPolicy& policy - Used to get the context for the type
 *
 * @return: std::optional<IR::Type>
 */
-std::optional<IR::Type> buildType(clang::QualType type);
+std::optional<IR::Type> buildType(clang::QualType type,
+                                  clang::PrintingPolicy options);
 
 }    // namespace Builders

--- a/src/Helpers/Type/utilities.cpp
+++ b/src/Helpers/Type/utilities.cpp
@@ -80,11 +80,7 @@ int getNumberOfPointers(clang::QualType type) {
 	return numPointers;
 }
 
-/**
-* Checks if type is const
-*/
 bool isConst(clang::QualType const& type) {
 	return type.split().Quals.hasConst();
 }
-
 }    // namespace Helpers::Type

--- a/src/Helpers/Type/utilities.hpp
+++ b/src/Helpers/Type/utilities.hpp
@@ -28,5 +28,4 @@ int getNumberOfPointers(clang::QualType type);
 * Checks if type is const
 */
 bool isConst(clang::QualType const& type);
-
 }    // namespace Helpers::Type

--- a/src/Visitor/VisitFieldDecl.cpp
+++ b/src/Visitor/VisitFieldDecl.cpp
@@ -1,5 +1,6 @@
 #include "Builders/commonBuilder.hpp"
 #include "Builders/typeBuilder.hpp"
+#include "Helpers/Type/utilities.hpp"
 #include "IRProxy/IRData.hpp"
 #include "Visitor/ParserVisitor.hpp"
 #include <spdlog/spdlog.h>
@@ -17,12 +18,16 @@ bool ParserVisitor::VisitFieldDecl(clang::FieldDecl* fieldDecl) {
 
 	IR::Variable variable;
 	variable.m_name = fieldDecl->getName();
-	// TODO: Handle type not being converted
-	if (auto type = Builders::buildType(fieldDecl->getType())) {
+
+	// This is passed so that while extracting text from types it is exactly what the user wrote
+	auto policy =
+	    clang::PrintingPolicy(fieldDecl->getASTContext().getLangOpts());
+
+	if (auto type = Builders::buildType(fieldDecl->getType(), policy)) {
 		variable.m_type = type.value();
 	} else {
 		spdlog::error("Failed to parse type {} for member variable {}",
-		              fieldDecl->getType().getAsString(),
+		              fieldDecl->getType().getAsString(policy),
 		              fieldDecl->getQualifiedNameAsString());
 		m_parsedSuccessfully = false;
 		// Stop parsing
@@ -49,5 +54,5 @@ bool ParserVisitor::VisitFieldDecl(clang::FieldDecl* fieldDecl) {
 
 	// Continue the AST search
 	return true;
-    }
-    }    // namespace Visitor
+}
+}    // namespace Visitor

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -47,6 +47,7 @@ foreach(
   dataStructs.cpp
   representation.cpp
   sets.cpp
+  strings.cpp
   unordered_maps.cpp
   unordered_sets.cpp
   userDefined.cpp

--- a/tests/arrays.cpp
+++ b/tests/arrays.cpp
@@ -5,9 +5,8 @@
 #include <variant>
 
 TEST_CASE("std::array of base type", "[arrays]") {
-	// TODO: There is a bug with std::string/bool (windows) within containers where the representation get garbled
 	for (auto baseType : TestUtil::getBaseTypes(
-	         /* excluding */ {"std::string", "void", "bool"})) {
+	         /* excluding */ {"std::string", "void"})) {
 		auto code = R"(
 #include <array>
 

--- a/tests/maps.cpp
+++ b/tests/maps.cpp
@@ -6,7 +6,7 @@
 
 TEST_CASE("std::map of base type", "[maps]") {
 	for (auto baseType : TestUtil::getBaseTypes(
-	         /* excluding */ {"std::string", "void", "bool"})) {
+	         /* excluding */ {"std::string", "void"})) {
 		auto code = R"(
 #include <map>
 

--- a/tests/strings.cpp
+++ b/tests/strings.cpp
@@ -1,0 +1,60 @@
+#include "TestUtil/parse.hpp"
+#include "TestUtil/types.hpp"
+#include <catch2/catch.hpp>
+#include <fmt/format.h>
+#include <variant>
+
+TEST_CASE("Function returning a string", "[strings]") {
+	auto code = R"(
+#include <string>
+
+std::string f();
+)";
+	CAPTURE(code);
+	auto globalNS = TestUtil::parseString(code);
+	REQUIRE(globalNS.m_functions.size() == 1);
+	auto& f = globalNS.m_functions.back();
+	auto& returnType = f.m_returnType;
+	REQUIRE(returnType.m_representation == "std::string");
+
+	auto& str = returnType.m_type;
+	auto stringType = std::get_if<IR::Type::Value>(&str);
+	REQUIRE(stringType != nullptr);
+
+	REQUIRE(stringType->m_base == IR::BaseType::String);
+}
+
+TEST_CASE("String nested in a container", "[strings]") {
+	auto code = R"(
+#include <string>
+#include <vector>
+
+std::vector<std::string> f();
+)";
+	CAPTURE(code);
+	auto globalNS = TestUtil::parseString(code);
+	REQUIRE(globalNS.m_functions.size() == 1);
+	auto& f = globalNS.m_functions.back();
+	auto& returnType = f.m_returnType;
+	REQUIRE(returnType.m_representation == "std::vector<std::string>");
+
+	auto& vec = returnType.m_type;
+	auto vecType = std::get_if<IR::Type::Container>(&vec);
+	REQUIRE(vecType != nullptr);
+
+	REQUIRE(vecType->m_container == IR::ContainerType::Vector);
+	// A vector also has an allocator
+	REQUIRE(vecType->m_containedTypes.size() == 2);
+	// But the first one should be the string
+	auto str = vecType->m_containedTypes.front();
+
+	// As of writing this only the top level type is what the user wrote
+	// (the nested levels removes aliases and using clauses so that we can indentify the type)
+	// The result here is typically "std::basic_string<char, std::char_traits<char>, std::allocator<char>>"
+	// but is dependent on the standard library used
+	// REQUIRE(str.m_representation == "std::string");
+	auto stringType = std::get_if<IR::Type::Value>(&str.m_type);
+	REQUIRE(stringType != nullptr);
+
+	REQUIRE(stringType->m_base == IR::BaseType::String);
+}

--- a/tests/unordered_maps.cpp
+++ b/tests/unordered_maps.cpp
@@ -6,7 +6,7 @@
 
 TEST_CASE("std::unordered_map of base types", "[unordered_map]") {
 	for (auto baseType : TestUtil::getBaseTypes(
-	         /* excluding */ {"std::string", "void", "bool"})) {
+	         /* excluding */ {"std::string", "void"})) {
 		auto code = R"(
 #include <unordered_map>
 

--- a/tests/unordered_sets.cpp
+++ b/tests/unordered_sets.cpp
@@ -6,7 +6,7 @@
 
 TEST_CASE("std::unordered_set of base type", "[unordered_sets]") {
 	for (auto baseType : TestUtil::getBaseTypes(
-	         /* excluding */ {"std::string", "void", "bool"})) {
+	         /* excluding */ {"std::string", "void"})) {
 		auto code =
 		    R"(
 #include <unordered_set>

--- a/tests/vectors.cpp
+++ b/tests/vectors.cpp
@@ -34,7 +34,7 @@ std::vector<std::vector<int>> f();
 
 TEST_CASE("std::vector<baseType>", "[vector]") {
 	for (auto baseType : TestUtil::getBaseTypes(
-	         /* excluding */ {"std::string", "void", "bool"})) {
+	         /* excluding */ {"std::string", "void"})) {
 		auto code = R"(
 #include <vector>
 


### PR DESCRIPTION
…sentation is what the user actually wrote

* The nested type levels (i.e. "std::string" in
  "std::vector<std::string>") is not required to be exactly what the
  user wrote. This is to ensure that we can identify the nested type by
  string. If this is necessary in the future, then this can be changed.

* Add a test for strings as they actually match "std::string" now